### PR TITLE
Run gemini chatbot on cloudflare workers for telegram

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gemini-telegram-bot",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "wrangler dev"
+  },
+  "devDependencies": {
+    "wrangler": "^3.52.1"
+  },
+  "dependencies": {
+    "@cf-workers/telegram-bot-api": "^0.1.0"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,47 @@
+export default {
+  async fetch(request, env, ctx) {
+    if (request.method === 'POST') {
+      const update = await request.json();
+      if (update.message) {
+        const chatId = update.message.chat.id;
+        const userMessage = update.message.text || '';
+
+        const reply = await getGeminiReply(userMessage, env.GEMINI_API_KEY);
+
+        await sendTelegramMessage(env.TELEGRAM_BOT_TOKEN, chatId, reply);
+      }
+      return new Response('OK');
+    }
+    return new Response('Hello, Gemini Telegram Bot!');
+  }
+};
+
+async function getGeminiReply(prompt, apiKey) {
+  const body = {
+    contents: [{ parts: [{ text: prompt }]}],
+    generationConfig: { temperature: 0.7, top_k: 40, top_p: 0.95 }
+  };
+  const resp = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  if (!resp.ok) {
+    return 'Error contacting Gemini API';
+  }
+  const data = await resp.json();
+  try {
+    return data.candidates[0].content.parts[0].text;
+  } catch (_) {
+    return 'Sorry, I could not parse Gemini response.';
+  }
+}
+
+async function sendTelegramMessage(token, chatId, text) {
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text })
+  });
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name = "gemini-telegram-bot"
+compatibility_date = "2024-06-12"
+
+[vars]
+# Set these in Cloudflare dashboard or via wrangler secret put
+TELEGRAM_BOT_TOKEN = ""
+GEMINI_API_KEY = ""


### PR DESCRIPTION
Implement a Telegram bot on Cloudflare Workers to integrate Google Gemini.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a5b0e34-7a92-443d-bbcb-d67e658a698e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a5b0e34-7a92-443d-bbcb-d67e658a698e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

